### PR TITLE
Update README.md to mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/alphagov/verify-stub-matching-service.svg?branch=master)](https://travis-ci.org/alphagov/verify-stub-matching-service)
 
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
 This is a stub implementation of the local matching service required by RP's to integrate into GOV.UK Verify.
 
 It is a small http server which provides 2 methods. These methods return successful responses.


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.